### PR TITLE
Cd 1024: remove deprecated warnings from ci

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -94,5 +94,5 @@ outputs:
     description: 'Info from testcase that has failures/errors/skipped, get from `junitxml`'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -36,6 +36,7 @@ const utils_1 = __nccwpck_require__(5278);
  *   ::name key=value,key=value::message
  *
  * Examples:
+ *   warning, {}, 'this is the message' gives:
  *   ::warning::This is the message
  *   ::set-env name=MY_VAR::some value
  */
@@ -49,6 +50,46 @@ function issue(name, message = '') {
 }
 exports.issue = issue;
 const CMD_STRING = '::';
+function issueOutput(env, key, value) {
+  const env_out = new Output(env, key, value);
+  process.stdout.write(env_out.toString() + os.EOL);
+}
+class Output {
+    constructor(env, key, value) {
+        if (!key) {
+          key = 'missing.key';
+        }
+        this.key = key;
+        this.value = value;
+        if (!env) {
+          env = 'missing.env'
+        }
+        this.env = env;
+    }
+    toString() {
+        var str_end = " >> $GITHUB_";
+        str_end += this.env.toUpperCase();
+        var cmd = '';
+
+        if (this.key && Object.keys(this.key).length > 0) {
+          let first = true;
+          for (const k in this.key) {
+            if (this.key.hasOwnProperty(k)){
+              const name = this.key[k];
+              if (name) {
+                first = false;
+              }
+              else {
+                cmd += ',';
+              }
+              cmd += `${escapeProperty(name)}=${escapeData(this.value)}`
+            }
+          }
+        }
+        cmd += str_end;
+        return cmd;
+    }
+}
 class Command {
     constructor(command, properties, message) {
         if (!command) {
@@ -270,7 +311,9 @@ function setOutput(name, value) {
         return file_command_1.issueFileCommand('OUTPUT', file_command_1.prepareKeyValueMessage(name, value));
     }
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
+    //command_1.issueCommand('set-output', { name }, value);
+    command_1.issueOutput('OUTPUT', { name }, value);
+    //corrected version doesnt even use command...
 }
 exports.setOutput = setOutput;
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -49,11 +49,12 @@ function issue(name, message = '') {
     issueCommand(name, {}, message);
 }
 exports.issue = issue;
-const CMD_STRING = '::';
+//consider writing to process.env.GITHUB_OUTPUT instead
 function issueOutput(env, key, value) {
   const env_out = new Output(env, key, value);
   process.stdout.write(env_out.toString() + os.EOL);
 }
+exports.issueOutput = issueOutput;
 class Output {
     constructor(env, key, value) {
         if (!key) {
@@ -90,6 +91,7 @@ class Output {
         return cmd;
     }
 }
+const CMD_STRING = '::';
 class Command {
     constructor(command, properties, message) {
         if (!command) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -36,6 +36,7 @@ const utils_1 = __nccwpck_require__(5278);
  *   ::name key=value,key=value::message
  *
  * Examples:
+ *   warning, {}, 'this is the message' gives:
  *   ::warning::This is the message
  *   ::set-env name=MY_VAR::some value
  */
@@ -49,6 +50,46 @@ function issue(name, message = '') {
 }
 exports.issue = issue;
 const CMD_STRING = '::';
+function issueOutput(env, key, value) {
+  const env_out = new Output(env, key, value);
+  process.stdout.write(env_out.toString() + os.EOL);
+}
+class Output {
+    constructor(env, key, value) {
+        if (!key) {
+          key = 'missing.key';
+        }
+        this.key = key;
+        this.value = value;
+        if (!env) {
+          env = 'missing.env'
+        }
+        this.env = env;
+    }
+    toString() {
+        var str_end = " >> $GITHUB_";
+        str_end += this.env.toUpperCase();
+        var cmd = '';
+
+        if (this.key && Object.keys(this.key).length > 0) {
+          let first = true;
+          for (const k in this.key) {
+            if (this.key.hasOwnProperty(k)){
+              const name = this.key[k];
+              if (name) {
+                first = false;
+              }
+              else {
+                cmd += ',';
+              }
+              cmd += `${escapeProperty(name)}=${escapeData(this.value)}`
+            }
+          }
+        }
+        cmd += str_end;
+        return cmd;
+    }
+}
 class Command {
     constructor(command, properties, message) {
         if (!command) {
@@ -267,7 +308,9 @@ exports.getBooleanInput = getBooleanInput;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, value);
+    //command_1.issueCommand('set-output', { name }, value);
+    command_1.issueOutput('OUTPUT', { name }, value);
+    //corrected version doesnt even use command...
 }
 exports.setOutput = setOutput;
 /**


### PR DESCRIPTION
most errors were from using the ::set-output github actions command. i've replaced them with a setting of the env_var $github_output 
the node versioning was fixed in the sync with the upstream fork.

 
note: there is a big block of code that is "changed" from line ~10365 or 10410 onwards, but if you check the split diff, it hasnt actually. not sure what caused that